### PR TITLE
fix: 修复状态栏错误显示 Free 套餐用量的问题

### DIFF
--- a/src/api/cache.rs
+++ b/src/api/cache.rs
@@ -122,7 +122,8 @@ pub fn spawn_background_subscription_update(api_key: String) {
         };
 
         if let Ok(client) = super::client::ApiClient::new(api_config) {
-            if let Ok(subs) = client.get_subscriptions() {
+            // 后台缓存更新时没有 model 信息，传 None
+            if let Ok(subs) = client.get_subscriptions(None) {
                 let _ = save_cached_subscriptions(&subs);
             }
         }
@@ -142,7 +143,8 @@ pub fn spawn_background_usage_update(api_key: String) {
         };
 
         if let Ok(client) = super::client::ApiClient::new(api_config) {
-            if let Ok(usage) = client.get_usage() {
+            // 后台缓存更新时没有 model 信息，传 None
+            if let Ok(usage) = client.get_usage(None) {
                 let _ = save_cached_usage(&usage);
             }
         }

--- a/src/core/segments/byebyecode_subscription.rs
+++ b/src/core/segments/byebyecode_subscription.rs
@@ -33,7 +33,7 @@ fn get_soft_color(text: &str) -> String {
 /// ANSI 重置代码
 const RESET: &str = "\x1b[0m";
 
-pub fn collect(config: &Config, _input: &InputData) -> Option<SegmentData> {
+pub fn collect(config: &Config, input: &InputData) -> Option<SegmentData> {
     // Get API config from segment options
     let segment = config
         .segments
@@ -95,9 +95,11 @@ pub fn collect(config: &Config, _input: &InputData) -> Option<SegmentData> {
     };
 
     // 实时获取数据，不使用缓存
-    let subscriptions = fetch_subscriptions_sync(&api_key)?;
+    // 传入 model 参数以获取正确的套餐信息
+    let model_id = &input.model.id;
+    let subscriptions = fetch_subscriptions_sync(&api_key, Some(model_id))?;
 
-    fn fetch_subscriptions_sync(api_key: &str) -> Option<Vec<crate::api::SubscriptionData>> {
+    fn fetch_subscriptions_sync(api_key: &str, model: Option<&str>) -> Option<Vec<crate::api::SubscriptionData>> {
         let api_config = ApiConfig {
             enabled: true,
             api_key: api_key.to_string(),
@@ -105,7 +107,7 @@ pub fn collect(config: &Config, _input: &InputData) -> Option<SegmentData> {
         };
 
         let client = ApiClient::new(api_config).ok()?;
-        let subs = client.get_subscriptions().ok()?;
+        let subs = client.get_subscriptions(model).ok()?;
         Some(subs)
     }
 


### PR DESCRIPTION
## 问题概述

状态栏始终显示 Free 套餐的用量（$0/$20），即使 Plus 套餐正在被扣费。

## 根本原因

API 即使传入 `model` 参数，顶层返回的仍然是 Free 套餐数据。实际的套餐用量数据在 `subscriptionEntityList` 数组中。

## 解决方案

1. 添加 `SubscriptionEntity` 结构体解析订阅列表
2. 修改 `calculate()` 方法，从列表中找到正在扣费的套餐（`currentCredits < creditLimit`）
3. 使用该套餐的 `creditLimit` 和 `currentCredits` 进行显示
4. 给 `/api/usage` 和 `/api/subscription` 都传入 `model` 参数

## 修改的文件

| 文件 | 改动 |
|------|------|
| `src/api/mod.rs` | 添加 `SubscriptionEntity` 结构体，修复 `calculate()` 逻辑 |
| `src/api/client.rs` | `get_usage()` 添加 `model` 参数 |
| `src/api/cache.rs` | 更新 `get_usage()` 调用 |
| `src/core/segments/byebyecode_usage.rs` | 传入 model 到 API |
| `src/core/segments/byebyecode_subscription.rs` | 传入 model 到 API |

## 测试计划

- [x] 项目构建成功
- [x] 验证状态栏显示正确的 Plus 套餐用量（如 `$4.53/$50`）
- [x] 确认 Free 套餐用户仍能正常显示

修复 #9

🤖 Generated with [Claude Code](https://claude.ai/code)