### PR TITLE
fix: Claude Code 环境下跳过 FREE 套餐

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -68,7 +68,10 @@ impl ApiClient {
         Ok(usage)
     }
 
-    pub fn get_subscriptions(&self, model: Option<&str>) -> Result<Vec<SubscriptionData>, Box<dyn std::error::Error>> {
+    pub fn get_subscriptions(
+        &self,
+        model: Option<&str>,
+    ) -> Result<Vec<SubscriptionData>, Box<dyn std::error::Error>> {
         // 构建请求体，传入 model 参数以获取正确的套餐信息
         // 如果不传 model，API 会默认返回 free 套餐
         let body = match model {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -147,12 +147,14 @@ impl UsageData {
 
 impl Code88UsageData {
     pub fn calculate(&mut self) {
-        // 优先从 subscriptionEntityList 中找到正在扣费的套餐
-        // 判断逻辑：is_active=true 且 currentCredits < creditLimit（已产生消费）
+        // 从 subscriptionEntityList 中找到正在扣费的套餐
+        // Claude Code 环境下跳过 FREE 套餐（FREE 不支持 CC）
+        // 选择第一个有消费（currentCredits < creditLimit）的非 FREE 活跃套餐
         let active_subscription = self
             .subscription_entity_list
             .iter()
             .filter(|s| s.is_active)
+            .filter(|s| s.subscription_name.to_uppercase() != "FREE") // 跳过 FREE
             .find(|s| s.current_credits < s.credit_limit);
 
         // 如果找到正在扣费的套餐，用那个套餐的数据

--- a/src/core/segments/byebyecode_subscription.rs
+++ b/src/core/segments/byebyecode_subscription.rs
@@ -99,7 +99,10 @@ pub fn collect(config: &Config, input: &InputData) -> Option<SegmentData> {
     let model_id = &input.model.id;
     let subscriptions = fetch_subscriptions_sync(&api_key, Some(model_id))?;
 
-    fn fetch_subscriptions_sync(api_key: &str, model: Option<&str>) -> Option<Vec<crate::api::SubscriptionData>> {
+    fn fetch_subscriptions_sync(
+        api_key: &str,
+        model: Option<&str>,
+    ) -> Option<Vec<crate::api::SubscriptionData>> {
         let api_config = ApiConfig {
             enabled: true,
             api_key: api_key.to_string(),

--- a/src/core/segments/byebyecode_usage.rs
+++ b/src/core/segments/byebyecode_usage.rs
@@ -64,7 +64,11 @@ pub fn collect(config: &Config, input: &InputData) -> Option<SegmentData> {
     let model_id = &input.model.id;
     let usage = fetch_usage_sync(&api_key, &usage_url, Some(model_id))?;
 
-    fn fetch_usage_sync(api_key: &str, usage_url: &str, model: Option<&str>) -> Option<crate::api::UsageData> {
+    fn fetch_usage_sync(
+        api_key: &str,
+        usage_url: &str,
+        model: Option<&str>,
+    ) -> Option<crate::api::UsageData> {
         let api_config = ApiConfig {
             enabled: true,
             api_key: api_key.to_string(),
@@ -146,7 +150,10 @@ pub fn collect(config: &Config, input: &InputData) -> Option<SegmentData> {
     let progress_bar = format!("{}{}", "▓".repeat(filled), "░".repeat(empty));
 
     Some(SegmentData {
-        primary: format!("${:.2}/${:.0} {}", used_dollars, total_dollars, progress_bar),
+        primary: format!(
+            "${:.2}/${:.0} {}",
+            used_dollars, total_dollars, progress_bar
+        ),
         secondary: String::new(),
         metadata,
     })


### PR DESCRIPTION
## 问题

FREE 套餐不支持 Claude Code（只支持 Codex），但状态栏可能错误地显示 FREE 套餐的用量。

## 修复

在选择显示哪个套餐时，跳过 FREE 套餐，显示 PLUS/PAYGO 等支持 CC 的套餐用量。

## 改动

```rust
.filter(|s| s.subscription_name.to_uppercase() != "FREE") // 跳过 FREE
```

🤖 Generated with [Claude Code](https://claude.ai/code)