### PR TITLE
fix: 只有 FREE + PAYGO 时显示 PAYGO 额度

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -163,6 +163,14 @@ impl UsageData {
             UsageData::Packy(data) => data.credit_limit,
         }
     }
+
+    /// 判断是否只有 FREE 套餐（仅 88code 支持）
+    pub fn has_only_free(&self) -> bool {
+        match self {
+            UsageData::Code88(data) => data.has_only_free(),
+            UsageData::Packy(_) => false, // Packy 不支持
+        }
+    }
 }
 
 impl Code88UsageData {
@@ -205,6 +213,20 @@ impl Code88UsageData {
 
     pub fn is_exhausted(&self) -> bool {
         self.current_credits <= 0.0
+    }
+
+    /// 判断是否只有 FREE 套餐（没有 PLUS/PRO/MAX）
+    /// 用于判断是否应该显示 PAYGO
+    pub fn has_only_free(&self) -> bool {
+        // 检查 subscriptionEntityList 中是否有 PLUS/PRO/MAX 套餐
+        // 排除 FREE 和 PAYGO
+        !self.subscription_entity_list.iter().any(|s| {
+            if !s.is_active {
+                return false;
+            }
+            let name = s.subscription_name.to_uppercase();
+            name != "FREE" && name != "PAYGO"
+        })
     }
 }
 


### PR DESCRIPTION
## Summary

- 修复 #22：用户只有 FREE + PAYGO 时，状态栏错误显示 FREE 额度
- 添加 `has_only_free()` 方法判断是否只有 FREE 套餐（没有 PLUS/PRO/MAX）
- 当只有 FREE 套餐时，从 Subscription API 获取 PAYGO 额度显示

## 问题分析

**场景**：用户只有 FREE + PAYGO 套餐（没有 PLUS/PRO/MAX）

**问题**：Usage API 的 `subscriptionEntityList` 不返回 PAYGO，导致 fallback 到 FREE 数据。但 Claude Code 不使用 FREE 额度，应该显示 PAYGO。

**解决方案**：
1. 添加 `has_only_free()` 方法检查 `subscriptionEntityList` 中是否只有 FREE（排除 PAYGO）
2. 如果只有 FREE，调用 Subscription API 获取 PAYGO 额度
3. 显示有余额的 PAYGO 套餐额度（蓝色）

## Test plan

- [x] 本地测试：只有 FREE + PAYGO 时正确显示 PAYGO 额度
- [x] 本地测试：有 PLUS 时正常显示 PLUS 额度（不受影响）
- [x] 本地测试：PLUS 用完后回退到 PAYGO（不受影响）

🤖 Generated with [Claude Code](https://claude.com/claude-code)